### PR TITLE
Replace `license-file` with `license`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "world"
 version = "0.1.0"
 edition = "2021"
-license-file = "LICENSE"
+license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/world_sys/Cargo.toml
+++ b/world_sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "world_sys"
 version = "0.1.0"
 edition = "2021"
-license-file = "WORLD/LICENSE.txt"
+license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Replaces the `license-file` fields with `license`.

[As described in Cargo Book](https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields), `license-file` is generally used for "nonstandard" licenses that are not in the SPDX list.

In actual, on Crates.io, the license section would be:
![image](https://github.com/White-Green/WORLD_rs/assets/14125495/d1c4ac6c-16c7-4453-befe-5e23960afd7c)
